### PR TITLE
explicitly specify hasher in default HashMap impl

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -76,7 +76,7 @@ pub struct HashMap<K: Hash + Eq, V, S: BuildHasher = FxBuildHasher> {
     hash_builder: Arc<S>,
 }
 
-impl<K: Hash + Eq, V> HashMap<K, V> {
+impl<K: Hash + Eq, V> HashMap<K, V, FxBuildHasher> {
     /// Creates an empty `HashMap`.
     ///
     /// The hash map is created with a capacity of 0 and will not allocate any


### PR DESCRIPTION
as per clippy's implicit hasher lint