### PR TITLE
add missing constructor methods to SegmentedHashMap

### DIFF
--- a/src/segment/map.rs
+++ b/src/segment/map.rs
@@ -82,7 +82,6 @@ use crossbeam_epoch::Atomic;
 /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
 /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
 /// [`Clone`]: https://doc.rust-lang.org/std/clone/trait.Clone.html
-#[derive(Default)]
 pub struct HashMap<K, V, S = DefaultHashBuilder> {
     segments: Box<[Segment<K, V>]>,
     build_hasher: S,
@@ -1042,6 +1041,13 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
 
         self.bucket_array_ref(hash)
             .modify_entry_and(key, hash, on_modify, with_old_entry)
+    }
+}
+
+#[cfg(feature = "num-cpus")]
+impl<K, V, S: Default> Default for HashMap<K, V, S> {
+    fn default() -> Self {
+        HashMap::with_num_segments_capacity_and_hasher(default_num_segments(), 0, S::default())
     }
 }
 

--- a/src/test_util/tests.rs
+++ b/src/test_util/tests.rs
@@ -953,5 +953,39 @@ macro_rules! write_test_cases_for_me {
 
             $crate::test_util::run_deferred();
         }
+
+        #[test]
+        fn default() {
+            let map = $m::<_, _, $crate::map::DefaultHashBuilder>::default();
+
+            assert!(map.is_empty());
+            assert_eq!(map.len(), 0);
+
+            assert_eq!(map.insert("foo", 5), None);
+            assert_eq!(map.insert("bar", 10), None);
+            assert_eq!(map.insert("baz", 15), None);
+            assert_eq!(map.insert("qux", 20), None);
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), 4);
+
+            assert_eq!(map.insert("foo", 5), Some(5));
+            assert_eq!(map.insert("bar", 10), Some(10));
+            assert_eq!(map.insert("baz", 15), Some(15));
+            assert_eq!(map.insert("qux", 20), Some(20));
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), 4);
+
+            assert_eq!(map.remove("foo"), Some(5));
+            assert_eq!(map.remove("bar"), Some(10));
+            assert_eq!(map.remove("baz"), Some(15));
+            assert_eq!(map.remove("qux"), Some(20));
+
+            assert!(map.is_empty());
+            assert_eq!(map.len(), 0);
+
+            $crate::test_util::run_deferred();
+        }
     };
 }


### PR DESCRIPTION
* `SegmentedHashMap#with_hasher`: Create with default capacity and number of segments, user-specified `BuildHasher`
* `SegmentedHashMap#with_capacity_and_hasher`: Create with default number of segments, user-specified capacity and `BuildHasher`
* `SegmentedHashMap#default`: Create with the default number of segments, capacity, and a default-constructed `BuildHasher`.

All constructors are gated behind the `num-cpus` feature, since I have decided that the API should require explicitly specifying the number of segments in the map.