### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,16 @@ default = ["num-cpus"]
 num-cpus = ["num_cpus"]
 
 [dependencies]
-ahash = "^0.3.2"
-crossbeam-epoch = "^0.8.2"
-num_cpus = { version = "^1.12.0", optional = true }
+ahash = "0.7"
+crossbeam-epoch = "0.9"
+num_cpus = { version = "1.12.0", optional = true }
 
 [dev-dependencies]
-criterion = "^0.3.1"
-hashbrown = "^0.7.0"
-lock_api = "^0.3.3"
-num_cpus = "^1.12.0"
-parking_lot = "^0.10.0"
+criterion = "0.3.1"
+hashbrown = "0.11"
+lock_api = "0.4"
+num_cpus = "1.12"
+parking_lot = "0.11"
 
 [[bench]]
 name = "cht"


### PR DESCRIPTION
This could be released a 0.5.0, since this also bumps the MSRV